### PR TITLE
Preserve executability with `cpr` alias

### DIFF
--- a/snowblocks/zsh/pkgs/rsync/aliases.zsh
+++ b/snowblocks/zsh/pkgs/rsync/aliases.zsh
@@ -6,5 +6,5 @@
 # License:    MIT
 
 # rsync based file system operations with detailed process and status information.
-alias cpr='rsync --archive -hh --partial --info=name2 --info=progress2 --info=stats1 --modify-window=1'
+alias cpr='rsync --archive --executability -hh --partial --info=name2 --info=progress2 --info=stats1 --modify-window=1'
 alias mvr='cpr --remove-source-files'


### PR DESCRIPTION
Resolves #288 