### PR TITLE
Fix missing root slashes in `fzf` absolute path of plugin loader script

### DIFF
--- a/snowblocks/zsh/lib/plugins.polarbear.zsh
+++ b/snowblocks/zsh/lib/plugins.polarbear.zsh
@@ -10,9 +10,9 @@
 #   1. https://github.com/zplug/zplug
 [[ -f $ZDOTDIR/lib/plugins-base.zsh ]] && source $ZDOTDIR/lib/plugins-base.zsh
 
-zplug "usr/share/fzf", \
+zplug "/usr/share/fzf", \
   from:local, \
-  if:"type fzf > /dev/null && [[ -d usr/share/fzf ]]", \
+  if:"type fzf > /dev/null && [[ -d /usr/share/fzf ]]", \
   use:"{completion,key-bindings}.zsh"
 
 # Load all plugins and add commands to the executable search path.


### PR DESCRIPTION
Fixes #290 